### PR TITLE
멀티 스테이지 빌드

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
+# 빌드 스테이지
+FROM gradle:7.4-jdk17-alpine AS build
+ARG GRADLE_USER_HOME="/gradle-cache/.gradle"
+ENV GRADLE_USER_HOME="${GRADLE_USER_HOME}"
+WORKDIR /app
+RUN mkdir -p "${GRADLE_USER_HOME}"
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+RUN gradle --no-daemon dependencies || return 0
+COPY . /app
+RUN chmod +x ./gradlew && gradle --no-daemon clean build
+
+# 런타임 스테이지
 FROM openjdk:17-jdk-alpine
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+COPY --from=build /app/build/libs/*.jar /app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","-Dspring.profiles.active=prod","/app.jar"]


### PR DESCRIPTION
## :white_check_mark:DONE
- Dockerfile 수정
  - 1차적으로 빌드 스테이지와 런타임 스테이지로 분리를 했습니다.
  - gradle 캐시 활용을 위한 설정을 통해 의존성 다운로드 시간을 줄였습니다.
## :white_check_mark:TODO
- 빌드 서버를 분리
## :white_check_mark:RESULT