### PR TITLE
my리뷰리스트 캐싱키 변경

### DIFF
--- a/src/main/java/site/matzip/matzip/controller/MatzipController.java
+++ b/src/main/java/site/matzip/matzip/controller/MatzipController.java
@@ -73,7 +73,6 @@ public class MatzipController {
         MatzipCreationDTO matzipCreationDTO = matzipReviewDTO.getMatzipCreationDTO();
         ReviewCreationDTO reviewCreationDTO = matzipReviewDTO.getReviewCreationDTO();
         Long authorId = principalDetails.getMember().getId();
-        Member author = principalDetails.getMember();
 
         Matzip createdMatzip = matzipService.create(matzipCreationDTO, authorId);
         Review createdReview = reviewService.create(reviewCreationDTO, authorId, createdMatzip);

--- a/src/main/java/site/matzip/matzip/service/MatzipService.java
+++ b/src/main/java/site/matzip/matzip/service/MatzipService.java
@@ -109,15 +109,10 @@ public class MatzipService {
     public RsData deleteMatzipMember(Long matzipId, Long authorId) {
         MatzipMember matzipMember = matzipMemberRepository.findByMatzipIdAndAuthorId(matzipId, authorId).orElse(null);
         if (matzipMember == null) {
-            return RsData.of("F-1", "이미 삭제된 맛집입니다");
-        }
-        Matzip matzip = matzipMember.getMatzip();
-        //누구의 맛집 지도에도 남아있지 않으면 맛집 자체를 삭제
-        if (matzip.getMatzipMembers().size() == 1) {
-            matzipRepository.delete(matzip);
+            return RsData.of("F-1", "이미 내 지도에서 삭제된 맛집입니다");
         }
         matzipMemberRepository.delete(matzipMember);
-        return RsData.of("S-1", "맛집이 삭제되었습니다.");
+        return RsData.of("S-1", "내 지도에서 맛집이 삭제되었습니다.");
     }
 
     //후기와 맛집 정보를 하나로 묶어서 MatzipListDTO로 변환

--- a/src/main/java/site/matzip/review/service/ReviewService.java
+++ b/src/main/java/site/matzip/review/service/ReviewService.java
@@ -95,7 +95,7 @@ public class ReviewService {
         return reviewPage.map(this::convertToReviewDTO);
     }
 
-    @Cacheable(value = "myReviewListCache", key = "#authorId")
+    @Cacheable(value = "myReviewListCache", key = "T(java.util.Objects).hash(#matzipId, #authorId)")
     public Page<ReviewListDTO> findByMatzipIdWithAuthorAndConvertToReviewDTO(Long matzipId, Long authorId, int pageSize, int pageNumber) {
         Sort sort = Sort.by(Sort.Direction.DESC, "views");
         Pageable pageable = PageRequest.of(pageNumber, pageSize, sort);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,3 +17,6 @@ spring:
         show_sql: false
         format_sql: false
         use_sql_comments: false
+server:
+  tomcat:
+    use-relative-redirects: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,9 @@ spring:
         #  show_sql: true
         format_sql: true
         use_sql_comments: true
-
+server:
+  tomcat:
+    use-relative-redirects: true
 logging.level:
   org.hibernate.SQL: debug
 management:


### PR DESCRIPTION
## :white_check_mark:DONE
- 나의 리뷰 리스트 오류 발견해서 캐시 키가 맛집,유저 id 모두 반영하게 fix
- 사용자 지도에서 맛집 삭제하는 부분 수정
- 톰캣 설정 추가
## :white_check_mark:TODO
- 누구의 맛집지도에도 남아있지 않을 때 삭제 되는 로직 추가(orphanRemoval로 테스트 해보는게 좋을듯)
## :white_check_mark:RESULT